### PR TITLE
Feat/webhook payment

### DIFF
--- a/app/model/models.py
+++ b/app/model/models.py
@@ -96,7 +96,7 @@ class Order(Base):
     order_items = relationship('OrderItem', back_populates='order')
     order_products = relationship('OrderProduct', back_populates='order')
     tracking = relationship('Tracking', back_populates='order')
-
+    webhook = relationship('Webhook', back_populates='order')
 
 class OrderItem(Base):
     """
@@ -204,3 +204,17 @@ class Category(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, unique=True, index=True)
     products = relationship('Product', back_populates='category')
+
+
+class Webhook(Base):
+
+    __tablename__ = 'webhook'
+
+    id = Column(Integer, primary_key=True, index=True)
+    order_id = Column(Integer, ForeignKey('orders.id'))
+    status = Column(String)
+    payment_status=Column(String)
+    received_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+    customer_id = Column(Integer)
+    order = relationship('Order', back_populates='webhook')

--- a/app/model/schemas.py
+++ b/app/model/schemas.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from pydantic import BaseModel, ConfigDict
 
 
+
 class CustomerBase(BaseModel):
     """
     Modelo Base para Dados de Clientes.
@@ -405,3 +406,23 @@ class UpdateOrderPaymentStatus(BaseModel):
     """
 
     payment_status: str
+
+class WebhookBase(BaseModel):
+    id: int
+    order_id: int
+    status: str
+    customer_id: int
+    payment_status: str
+    received_at: datetime
+
+class WebhookCreate(BaseModel):
+    order_id: int
+    customer_id: int
+    received_at: datetime
+
+class WebhookResponse(BaseModel):
+    order_id: int
+    status: str
+    customer_id: int
+    payment_status: str
+    received_at: datetime

--- a/app/routers/order.py
+++ b/app/routers/order.py
@@ -183,6 +183,7 @@ def fake_checkout(
         logger.error(f'Erro durante o checkout fictício: {e}', exc_info=True)
         raise HTTPException(status_code=500, detail='Erro Interno do Servidor')
 
+
 @router.patch('/{order_id}/payment', response_model=schemas.OrderResponse)
 def update_order_payment_status(
     order_id: str,
@@ -223,4 +224,23 @@ def update_order_payment_status(
         return db_order
     except Exception as e:
         logger.error(f'Erro ao atualizar o status de pagamento do pedido: {e}', exc_info=True)
+        raise HTTPException(status_code=500, detail='Erro Interno do Servidor')
+
+
+@router.post('/webhook', response_model=schemas.WebhookResponse)
+def create_webhook(
+    webhook: schemas.WebhookCreate,
+    db: Session = Depends(get_db),
+    current_user: schemas.Customer = Depends(security.get_current_user),
+) -> schemas.WebhookResponse:
+
+    logger.info('Endpoint de criação de webhook chamado')
+    try:
+        db_webhook = repository.create_webhook(db=db, webhook=webhook)
+        logger.info(
+            f'Endpoint de atualização de status do pedido chamado para o ID de pedido: {webhook.order_id}'
+        )
+        return db_webhook
+    except Exception as e:
+        logger.error(f'Erro ao criar o pedido: {e}', exc_info=True)
         raise HTTPException(status_code=500, detail='Erro Interno do Servidor')


### PR DESCRIPTION
## 📝 Descrição

Criação de rota /webhooks no serviço orders como método POST para criação de notificações Webhook registrando cada mudança de status de pagamento de um pedido previamente criado.

---

## 🔧 Tipo de Mudança

- [ ] Correção de Bug
- [x] Nova Funcionalidade
- [ ] Melhoria
- [ ] Refatoração de Código
- [ ] Documentação
- [ ] Outro (descreva)

---

## 🔗 Relacionado a

Relacionado ao CARD-42 - Webhook para receber confirmação de pagamento

---

## 🗒️ Notas Adicionais

Essa função ainda não está totalmente completa, dado que a API ainda não é disparada automaticamente assim que o status de pagamento de um pedido é alterado. Por hora, ela só pode ser chamada manualmente via swagger.
