### PR TITLE
Update release workflow to exclude 'doc/' branches from triggering version job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   version:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]' && !startsWith(github.ref_name, 'doc/')
     runs-on: ubuntu-latest
 
     outputs:


### PR DESCRIPTION
## 📝 Descrição
 A alteração garante que o pipeline release não será executado se o nome do branch começar com 'doc/'.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L19-R19): Adicionada condição para excluir branches que começam com 'doc/' de acionar o Workflow release.
---

## 🔧 Tipo de Mudança

- [ ] Correção de Bug
- [ ] Nova Funcionalidade
- [x] Melhoria
- [ ] Refatoração de Código
- [ ] Documentação
- [ ] Outro (descreva)

---
 🔗 Relacionado ao [CARD-65](https://software-architecture-fiap.atlassian.net/browse/CARD-65)
---